### PR TITLE
allow ValidationErrors to bubble up

### DIFF
--- a/generic_relations/relations.py
+++ b/generic_relations/relations.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django import forms
 
-from django.utils import six
+from rest_framework.compat import six
 from rest_framework import serializers
 
 


### PR DESCRIPTION
This PR is a proof-of-concept only (it's not bullet-proof); i'd like some discussion on it.

As i understand it, in `GenericRelatedField.determine_serializer_for_data(),` any validation error will prevent the serializer from being appended to serializers.  This, in turn, means that the specific validation error for that value will be displaced by "Could not determine a valid serializer for value" when the `ImproperlyConfigured` error is raised, because `len(serializers)` is 0.

Of course, some validation errors indicate that the serializer is not applicable.  What do you think of allowing a user to determine which error message really indicated a mismatch, and allow any other to bubble up?

In my particular use case, i was declaring a field this way:

```
content_object = GenericRelatedField({
    Foo: serializers.HyperlinkedRelatedField(view_name='foo-detail'),
    Bar: serializers.HyperlinkedRelatedField(view_name='bar-detail'),
})
```

With this change, i'm also able to declare this way, and this allows any validation error other than an incorrect match to bubble up (for example: "Invalid hyperlink - object does not exist."):

```
content_object = GenericRelatedField({
    Foo: serializers.HyperlinkedRelatedField(view_name='foo-detail'),
    Bar: serializers.HyperlinkedRelatedField(view_name='bar-detail'),
}, determining_errors=[serializers.HyperlinkedRelatedField.default_error_messages['incorrect_match']])
```

It'd be even better if we were passing a list of ValidationError subclasses, but in this case, that wasn't an option.  i presume this is i18n-friendly, but haven't tested it.