### PR TITLE
allow ValidationErrors to bubble up

### DIFF
--- a/generic_relations/relations.py
+++ b/generic_relations/relations.py
@@ -23,13 +23,20 @@ class GenericRelatedField(serializers.WritableField):
 
     form_field_class = forms.URLField
 
-    def __init__(self, serializers, *args, **kwargs):
+    def __init__(self, serializers, determining_errors=None, *args, **kwargs):
         """
         Needs an extra parameter `serializers` which has to be a dict
         key: value being `Model`: serializer.
+
+        Supports a `determining_errors` parameter which is a list of
+        ValidationError messages which should, in
+        determine_serializer_for_data(), indicate that the respective
+        serializer is not a match for the value. Default `None` means that any
+        ValidationError indicates a mismatch.
         """
         super(GenericRelatedField, self).__init__(*args, **kwargs)
         self.serializers = serializers
+        self.determining_errors = determining_errors
         for model, serializer in six.iteritems(self.serializers):
             # We have to do it, because the serializer can't access a
             # explicit manager through the GenericForeignKey field on
@@ -83,8 +90,12 @@ class GenericRelatedField(serializers.WritableField):
                 serializer.from_native(value)
                 # Collects all serializers that can handle the input data.
                 serializers.append(serializer)
-            except:
-                pass
+            except ValidationError as e:
+                if self.determining_errors and e.message not in self.determining_errors:
+                    # allow validation error to bubble up
+                    serializers.append(serializer)
+                else:
+                    pass
         # If no serializer found, raise error.
         l = len(serializers)
         if l < 1:


### PR DESCRIPTION
Sorry, botched the last PR; here we go again...

This PR is a proof-of-concept only (it's not bullet-proof); i'd like some discussion on it.

As i understand it, in `GenericRelatedField.determine_serializer_for_data(),` any validation error will prevent the serializer from being appended to serializers.  This, in turn, means that the specific validation error for that value will be displaced by "Could not determine a valid serializer for value" when the `ImproperlyConfigured` error is raised, because `len(serializers)` is 0.

Of course, some validation errors indicate that the serializer is not applicable.  What do you think of allowing a user to determine which error message really indicated a mismatch, and allow any other to bubble up?

In my particular use case, i was declaring a field this way:

```
content_object = GenericRelatedField({
    Foo: serializers.HyperlinkedRelatedField(view_name='foo-detail'),
    Bar: serializers.HyperlinkedRelatedField(view_name='bar-detail'),
})
```

With this change, i'm also able to declare this way, and this allows any validation error other than an incorrect match to bubble up (for example: "Invalid hyperlink - object does not exist."):

```
content_object = GenericRelatedField({
    Foo: serializers.HyperlinkedRelatedField(view_name='foo-detail'),
    Bar: serializers.HyperlinkedRelatedField(view_name='bar-detail'),
}, determining_errors=[serializers.HyperlinkedRelatedField.default_error_messages['incorrect_match']])
```

It'd be even better if we were passing a list of ValidationError subclasses, but in this case, that wasn't an option.  i presume this is i18n-friendly, but haven't tested it.
