### PR TITLE
Generic model serializer

### DIFF
--- a/generic_relations/relations.py
+++ b/generic_relations/relations.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals
 
 from django.utils.deprecation import RenameMethodsBase
-from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.utils.translation import ugettext_lazy as _
-from django import forms
 
 from rest_framework.compat import six
 from rest_framework import serializers
+
+from .serializers import GenericSerializerMixin
 
 
 __all__ = ('GenericRelatedField',)
@@ -19,69 +18,10 @@ class RenamedMethods(RenameMethodsBase):
     )
 
 
-class GenericRelatedField(six.with_metaclass(RenamedMethods, serializers.Field)):
+class GenericRelatedField(six.with_metaclass(RenamedMethods, GenericSerializerMixin, serializers.Field)):
     """
-    Represents a generic relation foreign key.
+    Represents a generic relation / foreign key.
     It's actually more of a wrapper, that delegates the logic to registered
     serializers based on the `Model` class.
     """
-    default_error_messages = {
-        'no_model_match': _('Invalid model - model not available.'),
-        'no_url_match': _('Invalid hyperlink - No URL match'),
-        'incorrect_url_match': _(
-            'Invalid hyperlink - view name not available'),
-    }
 
-    form_field_class = forms.URLField
-
-    def __init__(self, serializers, *args, **kwargs):
-        """
-        Needs an extra parameter `serializers` which has to be a dict
-        key: value being `Model`: serializer.
-        """
-        super(GenericRelatedField, self).__init__(*args, **kwargs)
-        self.serializers = serializers
-        for serializer in self.serializers.values():
-            serializer.bind('', self)
-
-    def to_internal_value(self, data):
-        try:
-            serializer = self.get_deserializer_for_data(data)
-        except ImproperlyConfigured as e:
-            raise ValidationError(e)
-        return serializer.to_internal_value(data)
-
-    def to_representation(self, instance):
-        serializer = self.get_serializer_for_instance(instance)
-        return serializer.to_representation(instance)
-
-    def get_serializer_for_instance(self, instance):
-        try:
-            model = instance.__class__
-            serializer = self.serializers[model]
-        except KeyError:
-            raise ValidationError(self.error_messages['no_model_match'])
-        return serializer
-
-    def get_deserializer_for_data(self, value):
-        # While one could easily execute the "try" block within
-        # to_internal_value and reduce operations, I consider the concept of
-        # serializing is already very naive and vague, that's why I'd
-        # go for stringency with the deserialization process here.
-        serializers = []
-        for serializer in six.itervalues(self.serializers):
-            try:
-                serializer.to_internal_value(value)
-                # Collects all serializers that can handle the input data.
-                serializers.append(serializer)
-            except:
-                pass
-        # If no serializer found, raise error.
-        l = len(serializers)
-        if l < 1:
-            raise ImproperlyConfigured(
-                'Could not determine a valid serializer for value %r.' % value)
-        elif l > 1:
-            raise ImproperlyConfigured(
-                'There were multiple serializers found for value %r.' % value)
-        return serializers[0]

--- a/generic_relations/serializers.py
+++ b/generic_relations/serializers.py
@@ -1,0 +1,81 @@
+from __future__ import unicode_literals
+
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.utils.translation import ugettext_lazy as _
+from django import forms
+
+from rest_framework.compat import six
+from rest_framework import serializers
+
+
+__all__ = ('GenericSerializerMixin', 'GenericModelSerializer',)
+
+
+class GenericSerializerMixin(object):
+    default_error_messages = {
+        'no_model_match': _('Invalid model - model not available.'),
+        'no_url_match': _('Invalid hyperlink - No URL match'),
+        'incorrect_url_match': _(
+            'Invalid hyperlink - view name not available'),
+    }
+
+    form_field_class = forms.URLField
+
+    def __init__(self, serializers, *args, **kwargs):
+        """
+        Needs an extra parameter `serializers` which has to be a dict
+        key: value being `Model`: serializer.
+        """
+        super(GenericSerializerMixin, self).__init__(*args, **kwargs)
+        self.serializers = serializers
+        for serializer in self.serializers.values():
+            serializer.bind('', self)
+
+    def to_internal_value(self, data):
+        try:
+            serializer = self.get_deserializer_for_data(data)
+        except ImproperlyConfigured as e:
+            raise ValidationError(e)
+        return serializer.to_internal_value(data)
+
+    def to_representation(self, instance):
+        serializer = self.get_serializer_for_instance(instance)
+        return serializer.to_representation(instance)
+
+    def get_serializer_for_instance(self, instance):
+        try:
+            model = instance.__class__
+            serializer = self.serializers[model]
+        except KeyError:
+            raise ValidationError(self.error_messages['no_model_match'])
+        return serializer
+
+    def get_deserializer_for_data(self, value):
+        # While one could easily execute the "try" block within
+        # to_internal_value and reduce operations, I consider the concept of
+        # serializing is already very naive and vague, that's why I'd
+        # go for stringency with the deserialization process here.
+        serializers = []
+        for serializer in six.itervalues(self.serializers):
+            try:
+                serializer.to_internal_value(value)
+                # Collects all serializers that can handle the input data.
+                serializers.append(serializer)
+            except:
+                pass
+        # If no serializer found, raise error.
+        l = len(serializers)
+        if l < 1:
+            raise ImproperlyConfigured(
+                'Could not determine a valid serializer for value %r.' % value)
+        elif l > 1:
+            raise ImproperlyConfigured(
+                'There were multiple serializers found for value %r.' % value)
+        return serializers[0]
+
+
+class GenericModelSerializer(GenericSerializerMixin, serializers.Serializer):
+    """
+    Delegates serialization and deserialization to registered serializers
+    based on the type of the model.
+    """

--- a/generic_relations/tests/test_serializers.py
+++ b/generic_relations/tests/test_serializers.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from rest_framework import serializers
+
+from generic_relations.serializers import GenericModelSerializer
+from generic_relations.tests.models import Bookmark, Note
+
+from .test_relations import BookmarkSerializer, NoteSerializer
+
+
+class TestGenericModelSerializer(TestCase):
+    def setUp(self):
+        self.bookmark = Bookmark.objects.create(
+            url='https://www.djangoproject.com/')
+        self.note = Note.objects.create(text='Remember the milk')
+        self.note2 = Note.objects.create(text='Reticulate the splines')
+
+        self.serializer = GenericModelSerializer(
+            {
+                Bookmark: BookmarkSerializer(),
+                Note: NoteSerializer(),
+            }
+        )
+        self.list_serializer = serializers.ListSerializer(child=self.serializer)
+
+    def test_serialize(self):
+        self.assertEqual(
+            self.serializer.to_representation(self.bookmark),
+            {'url': 'https://www.djangoproject.com/'},
+        )
+        self.assertEqual(
+            self.serializer.to_representation(self.note),
+            {'text': 'Remember the milk'},
+        )
+
+    def test_deserialize(self):
+        self.assertEqual(
+            self.serializer.to_internal_value({'url': 'https://www.djangoproject.com/'}),
+            {'url': 'https://www.djangoproject.com/'},
+        )
+        self.assertEqual(
+            self.serializer.to_internal_value({'text': 'Remember the milk'}),
+            {'text': 'Remember the milk'},
+        )
+
+    def test_serialize_list(self):
+        actual = self.list_serializer.to_representation([
+            self.bookmark, self.note, self.note2, self.bookmark,
+        ])
+        expected = [
+            {'url': 'https://www.djangoproject.com/'},
+            {'text': 'Remember the milk'},
+            {'text': 'Reticulate the splines'},
+            {'url': 'https://www.djangoproject.com/'},
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_deserialize_list(self):
+        validated_data = self.list_serializer.to_internal_value([
+            {'url': 'https://www.djangoproject.com/'},
+            {'text': 'Remember the milk'},
+            {'text': 'Reticulate the splines'},
+            {'url': 'https://www.djangoproject.com/'},
+        ])
+
+        self.assertEqual(validated_data, [
+            {'url': 'https://www.djangoproject.com/'},
+            {'text': 'Remember the milk'},
+            {'text': 'Reticulate the splines'},
+            {'url': 'https://www.djangoproject.com/'},
+        ])


### PR DESCRIPTION
Moves most of the code for `GenericRelatedField` into a mixin, and uses it for `GenericModelSerializer` too.

Also, I was adding stuff to the README for this field, and ended up tweaking some of what's there, which might go some way towards #17, though there might be more you'd like to do for that.
