### PR TITLE
Handle subclasses using a registered serializer for the superclass.

### DIFF
--- a/generic_relations/tests/models.py
+++ b/generic_relations/tests/models.py
@@ -47,3 +47,8 @@ class Note(models.Model):
 
     def __unicode__(self):
         return 'Note: %s' % self.text
+
+
+class NoteProxy(Note):
+    class Meta:
+        proxy = True


### PR DESCRIPTION
This is useful for (e.g.) proxy models. If you have 5 proxy models all referencing a common base, it's useful to be able to just add the common base to `GenericRelatedField.serializers` and expect all the subclasses will use it.

Ties in well with my app https://github.com/craigds/django-typed-models , but should make things better for anyone with any kind of model hierarchy.