### PR TITLE
fix Django 3 compatibility by importing six directly

### DIFF
--- a/generic_relations/relations.py
+++ b/generic_relations/relations.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.utils import six
+import six
 from django.utils.deprecation import RenameMethodsBase
 
 from rest_framework import serializers

--- a/generic_relations/serializers.py
+++ b/generic_relations/serializers.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
+import six
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django import forms
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 version = '1.2.2'
 
 install_requires = [
-    'djangorestframework>=3.0.0,<3.11',
+    'djangorestframework>=3.0.0',
     'six>=1.13.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ version = '1.2.2'
 
 install_requires = [
     'djangorestframework>=3.0.0,<3.11',
+    'six>=1.13.0',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {py34,py35,py36,py37}-dj20-{drf37,drf38,drf39}
     {py35,py36,py37}-dj21-drf39
     {py35,py36,py37}-{dj111,dj20,dj21,dj22}-{drf310}
+    {py37}-{dj30}-{drf311}
 [testenv]
 changedir = {toxinidir}
 commands = ./manage.py test --settings=testsettings {posargs}
@@ -19,8 +20,10 @@ deps =
     dj20: Django~=2.0.13
     dj21: Django~=2.1.10
     dj22: Django~=2.2.3
+    dj30: Django~=3.0.0
     drf36: djangorestframework~=3.6.4
     drf37: djangorestframework~=3.7.7
     drf38: djangorestframework~=3.8.2
     drf39: djangorestframework~=3.9.4
     drf310: djangorestframework~=3.10.2
+    drf311: djangorestframework~=3.11.0


### PR DESCRIPTION
because `django.utils` stopped including `six` in Django 3.0