### PR TITLE
Fixes deprecation warning for `ugettext_lazy`

### DIFF
--- a/generic_relations/serializers.py
+++ b/generic_relations/serializers.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django import forms
 
 from rest_framework import serializers


### PR DESCRIPTION
Hey there, thanks for releasing this package! Proposing this PR to remove these annoying nags, appreciate the hard work :)

Fix for the following deprecation warning:

```
  /usr/local/lib/python3.8/site-packages/generic_relations/serializers.py:13: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    'no_model_match': _('Invalid model - model not available.'),
```